### PR TITLE
chore: Improve VM property checking

### DIFF
--- a/src/firewheel_repo_linux/ubuntu/bionic/model_component_objects.py
+++ b/src/firewheel_repo_linux/ubuntu/bionic/model_component_objects.py
@@ -28,25 +28,25 @@ class Ubuntu1804Server:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 512
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-18.04.5-server-amd64.qcow2.tgz",
                     "file": "ubuntu-18.04.5-server-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1804server")
@@ -65,25 +65,25 @@ class Ubuntu1804Desktop:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 2,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 2048
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-18.04.5-desktop-amd64.qcow2.tgz",
                     "file": "ubuntu-18.04.5-desktop-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1804Desktop")

--- a/src/firewheel_repo_linux/ubuntu/jammy/model_component_objects.py
+++ b/src/firewheel_repo_linux/ubuntu/jammy/model_component_objects.py
@@ -62,25 +62,25 @@ class Ubuntu2204Server:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 1024
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-22.04-server-amd64.qcow2.tgz",
                     "file": "ubuntu-22.04-server-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu2204server")
@@ -99,25 +99,25 @@ class Ubuntu2204Desktop:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 2,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 2048
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-22.04-desktop-amd64.qcow2.tgz",
                     "file": "ubuntu-22.04-desktop-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu2204desktop")

--- a/src/firewheel_repo_linux/ubuntu/trusty/model_component_objects.py
+++ b/src/firewheel_repo_linux/ubuntu/trusty/model_component_objects.py
@@ -26,25 +26,25 @@ class Ubuntu1404Server:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 256
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-14.04.5-server-amd64.qc2.xz",
                     "file": "ubuntu-14.04.5-server-amd64.qc2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1404server")
@@ -63,25 +63,25 @@ class Ubuntu1404Desktop:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 1024
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-14.04.5-desktop-amd64.qcow2.xz",
                     "file": "ubuntu-14.04.5-desktop-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1404desktop")

--- a/src/firewheel_repo_linux/ubuntu/xenial/model_component_objects.py
+++ b/src/firewheel_repo_linux/ubuntu/xenial/model_component_objects.py
@@ -26,25 +26,25 @@ class Ubuntu1604Server:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 1,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 256
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-16.04.4-server-amd64.qcow2.xz",
                     "file": "ubuntu-16.04.4-server-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1604server")
@@ -63,25 +63,25 @@ class Ubuntu1604Desktop:
         """
         self.vm = getattr(self, "vm", {})
 
-        if "architecture" not in self.vm:
+        if not self.vm.get("architecture"):
             self.vm["architecture"] = "x86_64"
-        if "vcpu" not in self.vm:
+        if not self.vm.get("vcpu"):
             self.vm["vcpu"] = {
                 "model": "qemu64",
                 "sockets": 1,
                 "cores": 2,
                 "threads": 1,
             }
-        if "mem" not in self.vm:
+        if not self.vm.get("mem"):
             self.vm["mem"] = 2048
-        if "drives" not in self.vm:
+        if not self.vm.get("drives"):
             self.vm["drives"] = [
                 {
                     "db_path": "ubuntu-16.04.4-desktop-amd64.qcow2.xz",
                     "file": "ubuntu-16.04.4-desktop-amd64.qcow2",
                 }
             ]
-        if "vga" not in self.vm:
+        if not self.vm.get("vga"):
             self.vm["vga"] = "std"
 
         self.set_image("ubuntu1604Desktop")


### PR DESCRIPTION
Improve VM property checking for falsy values rather than just missing keys in the Vertex `vm` dictionary. This is the "proper" way to check a dictionary and will also provide more robust checks.