### PR TITLE
refactor: Split the logic from configure IPs to enable future extensability of the `configure_ips.sh` VMR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,37 +105,37 @@ select = [
 
 # We may want to adhere to D205 and D415 in the future.
 ignore = [
-    "D100",     # Missing docstring in public module
-    "D105",     # Missing docstring in magic method
-    "D104",     # Missing docstring in public package
-    "D200",     # One-line docstring should fit on one line with quotes
-    "D202",     # No blank lines allowed after function docstring
-    "D205",     # 1 blank line required between summary line and description
-    "D212",     # Multi-line docstring summary should start at the first line
-    "D415",     # First line should end with a period, question mark, or exclamation point
-    "S101",     # Ignore assert statements
-    "S403",     # Ignore warnings about importing pickle
-    "S301",     # suspicious-pickle-usage
-    "S603",     # subprocess-without-shell-equals-true
-    "S404",     # Ignore warnings about importing subprocess
-    "S311",     # Ignore warnings about using random
-    "S608",     # Ignore warning about possible SQL injection. SQL is not used in FIREWHEEL.
-    "PLW2901",  # redefined-loop-name
-    "RUF100",   # unused-noqa
-    "RUF012",   # mutable-class-default
-    "PLR0904",  # too-many-public-methods
-    "PLR0911",  # too-many-return-statements
-    "PLR0912",  # too-many-branches
-    "PLR0913",  # too-many-arguments
-    "PLR0914",  # too-many-locals
-    "PLR0915",  # too-many-statements
-    "PLR1702",  # too-many-nested-blocks
-    "PLR0917",  # too-many-positional-arguments
-    "PLR2004",  # magic-value-comparison
-    "PLR6301",  # no-self-use
-    "DOC502",   # docstring-extraneous-exception -- Has lots of false positives currently
-    "PERF203",  # try-except-in-loop
-    "PERF401",  # manual-list-comprehension
+    "undocumented-public-module",     # Missing docstring in public module
+    "undocumented-magic-method",     # Missing docstring in magic method
+    "undocumented-public-package",     # Missing docstring in public package
+    "unnecessary-multiline-docstring",     # One-line docstring should fit on one line with quotes
+    "blank-line-after-function",     # No blank lines allowed after function docstring
+    "missing-blank-line-after-summary",     # 1 blank line required between summary line and description
+    "multi-line-summary-first-line",     # Multi-line docstring summary should start at the first line
+    "missing-terminal-punctuation",     # First line should end with a period, question mark, or exclamation point
+    "assert",     # Ignore assert statements
+    "suspicious-pickle-import",     # Ignore warnings about importing pickle
+    "suspicious-pickle-usage",     # suspicious-pickle-usage
+    "subprocess-without-shell-equals-true",     # subprocess-without-shell-equals-true
+    "suspicious-subprocess-import",     # Ignore warnings about importing subprocess
+    "suspicious-non-cryptographic-random-usage",     # Ignore warnings about using random
+    "hardcoded-sql-expression",     # Ignore warning about possible SQL injection. SQL is not used in FIREWHEEL.
+    "redefined-loop-name",  # redefined-loop-name
+    "unused-noqa",   # unused-noqa
+    "mutable-class-default",   # mutable-class-default
+    "too-many-public-methods",  # too-many-public-methods
+    "too-many-return-statements",  # too-many-return-statements
+    "too-many-branches",  # too-many-branches
+    "too-many-arguments",  # too-many-arguments
+    "too-many-locals",  # too-many-locals
+    "too-many-statements",  # too-many-statements
+    "too-many-nested-blocks",  # too-many-nested-blocks
+    "too-many-positional-arguments",  # too-many-positional-arguments
+    "magic-value-comparison",  # magic-value-comparison
+    "no-self-use",  # no-self-use
+    "docstring-extraneous-exception",   # docstring-extraneous-exception -- Has lots of false positives currently
+    "try-except-in-loop",  # try-except-in-loop
+    "manual-list-comprehension",  # manual-list-comprehension
 ]
 preview = true
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/src/firewheel_repo_linux/linux/model_component_objects.py
+++ b/src/firewheel_repo_linux/linux/model_component_objects.py
@@ -117,12 +117,9 @@ class LinuxHost:
         )
         self.run_executable(-246, "rm", "-f /root/combined_profiles.tgz")
 
-    def _configure_ips(self, start_time=-200):
+    def _configure_ips(self):
         """
         Create the format for configuring the IP addresses of Linux VMs
-
-        Args:
-            start_time (int): The start time to configure the VM's hostname (default=-200)
 
         Returns:
             str: The completed configuration
@@ -176,7 +173,7 @@ class LinuxHost:
         Returns:
             bool: True if successful, False otherwise.
         """
-        config = self._configure_ips(start_time=start_time)
+        config = self._configure_ips()
 
         if not config:
             return
@@ -247,7 +244,9 @@ class LinuxHost:
             exec_vm_resource.add_file(archive, archive)
 
 
-def configure_ip_conflict_handler(entry_name, _decorator_value, _current_instance_value):
+def configure_ip_conflict_handler(
+    entry_name, _decorator_value, _current_instance_value
+):
     """
     The conflict handler for functions overwritten in LinuxNetplanHost that are
     also implemented in LinuxHost, i.e. the ``configure_ips`` function.

--- a/src/firewheel_repo_linux/linux/model_component_objects.py
+++ b/src/firewheel_repo_linux/linux/model_component_objects.py
@@ -117,15 +117,15 @@ class LinuxHost:
         )
         self.run_executable(-246, "rm", "-f /root/combined_profiles.tgz")
 
-    def configure_ips(self, start_time=-200):
+    def _configure_ips(self, start_time=-200):
         """
-        Configure the IP addresses of the VM
+        Create the format for configuring the IP addresses of Linux VMs
 
         Args:
             start_time (int): The start time to configure the VM's hostname (default=-200)
 
         Returns:
-            bool: True if successful, False otherwise.
+            str: The completed configuration
         """
         self.interfaces = getattr(self, "interfaces", None)
         if not self.interfaces:
@@ -162,9 +162,24 @@ class LinuxHost:
                 config += "\n"
 
         if not config:
-            return
+            return ""
 
-        config = f"{nameservers}\n{config}"
+        return f"{nameservers}\n{config}"
+
+    def configure_ips(self, start_time=-200):
+        """
+        Configure the IP addresses of the VM
+
+        Args:
+            start_time (int): The start time to configure the VM's hostname (default=-200)
+
+        Returns:
+            bool: True if successful, False otherwise.
+        """
+        config = self._configure_ips(start_time=start_time)
+
+        if not config:
+            return
 
         self.add_vm_resource(start_time, "configure_ips.sh", config)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [testenv:ruff]
 basepython = python3
-deps = ruff==0.7.1
+deps = ruff~=0.16.0
 commands =
     ruff check {posargs}
 


### PR DESCRIPTION
This PR breaks apart the logic from creating the input to the `configure_ips.sh` so that it can be overridden by future model components that may be linux based, but use a different VMR for setting the IP address.