### PR TITLE
style: Use project formatting dependencies and enforce Ruff format checks

### DIFF
--- a/src/firewheel_repo_linux/linux/model_component_objects.py
+++ b/src/firewheel_repo_linux/linux/model_component_objects.py
@@ -232,7 +232,9 @@ class LinuxHost:
             exec_vm_resource.add_file(archive, archive)
 
 
-def configure_ip_conflict_handler(entry_name, _decorator_value, _current_instance_value):
+def configure_ip_conflict_handler(
+    entry_name, _decorator_value, _current_instance_value
+):
     """
     The conflict handler for functions overwritten in LinuxNetplanHost that are
     also implemented in LinuxHost, i.e. the ``configure_ips`` function.

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
 
 [testenv:ruff]
 basepython = python3
-deps = ruff==0.7.1
+deps = firewheel[format]
 commands =
     ruff check {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
 basepython = python3
 deps = {[testenv:ruff]deps}
 commands =
+    ruff check --select I --fix {toxinidir}/src
     ruff format {toxinidir}/src
 
 # Linters

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ basepython = python3
 deps = {[testenv:ruff]deps}
 commands =
     {[testenv:ruff]commands}
+    ruff format --check {toxinidir}/src
 
 [testenv:lint-docs]
 basepython = python3


### PR DESCRIPTION
This updates the Ruff linting tox environment to use the project’s formatting dependencies and adds a formatting check for the `src` directory when running `tox -e lint`.

It also applies formatting cleanup across files corresponding to the updated Ruff version to satisfy the linter.